### PR TITLE
[cl_tf2] Added conversion from msg to Point, Pose and PoseStamped.

### DIFF
--- a/cl_tf2/src/message-conversions.lisp
+++ b/cl_tf2/src/message-conversions.lisp
@@ -108,6 +108,27 @@ If you need a geometry_msgs/Point use the MAKE-POINT-MSG function."
   (with-fields (x y z w) msg
     (make-instance 'cl-transforms:quaternion :x x :y y :z z :w w)))
 
+(defmethod from-msg ((msg geometry_msgs-msg:Point))
+  (with-fields (x y z) msg
+    (make-instance 'cl-transforms:3d-vector :x x :y y :z z)))
+
+(defmethod from-msg ((msg geometry_msgs-msg:Pose))
+  (with-fields (orientation position) msg
+    (make-instance 'cl-transforms:pose
+      :origin (from-msg position) :orientation (from-msg orientation))))
+
+(defmethod from-msg ((msg geometry_msgs-msg:PoseStamped))
+  (with-fields ((frame-id (frame_id header))
+                (stamp (stamp header))
+                (position-msg (position pose))
+                (orientation-msg (orientation pose)))
+      msg
+    (make-instance 'cl-tf-datatypes:pose-stamped
+                   :frame-id frame-id
+                   :stamp stamp
+                   :origin (from-msg position-msg)
+                   :orientation (from-msg orientation-msg))))
+
 (defun make-header-msg (stamp frame-id)
   (make-msg "std_msgs/Header"
             :stamp stamp

--- a/cl_tf2/src/package.lisp
+++ b/cl_tf2/src/package.lisp
@@ -39,7 +39,7 @@
            execute-changed-callbacks add-transforms-changed-callback
            remove-transforms-changed-callback enable-changed-callbacks
            disable-changed-callbacks with-transforms-changed-callbacks
-           to-msg transform-pose transform-point
+           to-msg from-msg transform-pose transform-point
            tf2-server-error
            tf2-lookup-error tf2-connectivity-error tf2-extrapolation-error
            tf2-invalid-argument-error tf2-timeout-error tf2-transform-error))


### PR DESCRIPTION
* Exported method `from-msg` in `message-conversion.lisp`.
* Added conversion from `msg geometry_msgs-msg:Point` to `cl-transforms:pose`.
* Added conversion from `geometry_msgs-msg:Pose` to `cl-transforms:pose`.
* Added conversion from `geometry_msgs-msg:PoseStamped` to `cl-tf-datatypes:pose-stamped`.